### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Pin `com.enonic.lib:lib-util` to the next-major SNAPSHOT published from its master branch (XP 8 upgrade). The lib has not been released yet; consumers need the SNAPSHOT pin in the meantime.

| Coordinate | Before | After |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` |

The new pin is a SNAPSHOT and resolves from `xp.enonicRepo('dev')`, which is already declared in `build.gradle` — no repo declaration was added.

## Excludes

- **Removed:** none — the repo had no `exclude` clauses on enonic libs to begin with (`grep -r exclude` across the project returns nothing).
- **Kept:** none.

The lib-util 4.0.0-SNAPSHOT dependency tree is clean — `./gradlew dependencies --configuration include` shows it pulls no transitive XP modules, so no excludes were needed and none were added.

## Verification

- `./gradlew clean build` — green.
- `./gradlew dependencies --configuration include` confirms `lib-util:4.0.0-SNAPSHOT` resolves.
- Runtime verification was **not** performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)