### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = hubspot
 appName = com.enonic.app.hubspot
 xpVersion=8.0.0-B4
-version=2.0.2-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bumps `version` in `gradle.properties` from `2.0.2-SNAPSHOT` to `3.0.0-SNAPSHOT`, opening master for the XP 8 line.
- Adds a `releaseBranch:` config to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so release-tools recognizes both as release branches.
- Maintenance line for XP 7 lives on the new `2.x` branch (forked from post-release SNAPSHOT commit `30ae114`).

## Test plan
- [ ] CI on this PR passes (`./gradlew clean build` is green).
- [ ] After merge, a push to `master` is recognized as a release-branch build.
- [ ] Companion PR on `2.x` adds the same `releaseBranch:` config so pushes to `2.x` are also recognized.