### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `releaseBranch:` config to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so pushes to `2.x` are recognized as release-branch builds by `enonic/release-tools`.
- Companion to the master PR (#48). No version bump or other changes — this branch stays on `2.0.2-SNAPSHOT` for the XP 7 maintenance line.

## Test plan
- [ ] After merge, a push to `2.x` is classified as a release-branch build by the workflow.
- [ ] `gradle.properties` on `2.x` remains at `version=2.0.2-SNAPSHOT` (XP 7 maintenance line continues).