### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     include xplibs.content
     include xplibs.portal
     include libs.lib.thymeleaf
-    include libs.lib.util
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util      = { module = "com.enonic.lib:lib-util",      version.ref = "util" }

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 var view = resolve('add-script.html');
@@ -13,7 +12,7 @@ exports.responseProcessor = function (req, res) {
 
 	// If no pixel code added to app, send null so that no script will be generated.
 	var params = {
-		hubspotID: libs.util.data.isSet(siteConfig.hubspotID) ? siteConfig.hubspotID : null
+		hubspotID: siteConfig.hubspotID != null ? siteConfig.hubspotID : null
 	};
 
 	// We don't want this code inside Content Studio, only in live mode.
@@ -21,7 +20,7 @@ exports.responseProcessor = function (req, res) {
 		var metadata = libs.thymeleaf.render(view, params);
 
 		// Force arrays since single values will be return as string instead of array
-		res.pageContributions.headEnd = libs.util.data.forceArray(res.pageContributions.headEnd);
+		res.pageContributions.headEnd = Array.isArray(res.pageContributions.headEnd) ? res.pageContributions.headEnd : [res.pageContributions.headEnd];
 		res.pageContributions.headEnd.push(metadata);
 	}
 


### PR DESCRIPTION
## Summary

Drop the `lib-util` dependency by inlining its two call sites.

`src/main/resources/cms/processors/add-script.js` was the only consumer:

- `util.data.isSet(siteConfig.hubspotID)` → `siteConfig.hubspotID != null`
- `util.data.forceArray(res.pageContributions.headEnd)` → `Array.isArray(...) ? ... : [...]`

Also removes the `lib-util` entry from `gradle/libs.versions.toml` (both `[versions]` and `[libraries]` blocks) and the `include libs.lib.util` line from `build.gradle`.

Behavior is byte-identical — Nashorn-safe ES5.

## Files touched

- `src/main/resources/cms/processors/add-script.js`
- `gradle/libs.versions.toml`
- `build.gradle`

## Test plan

- [x] `./gradlew build` passes
- [ ] CI green